### PR TITLE
Update release asset names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           args: --target ${{ matrix.gui_target }}
           tagName: ${{ needs.ensure-release.outputs.release-name }}
-          assetNamePattern: "[name]-[arch][ext]"
+          assetNamePattern: "tidewave-app-[arch][ext]"
 
       - name: Verify GUI notarization (macos)
         if: startsWith(matrix.platform, 'macos')


### PR DESCRIPTION
They are currently all over the place:

<img width="504" height="675" alt="image" src="https://github.com/user-attachments/assets/c6da67cf-5d48-465c-927f-d9b1681cd272" />

having a consistent prefix of `tidewave-app-` will add some order. It will still be not totally consistent, e.g.: `tidewave-app-aarch64.dmg` vs `tidewave-app-x64.dmg` vs `tidewave-app-amd64.AppImage` but 1. I blame this on Tauri and 2. nobody cares.