### PR TITLE
Expose /about route without origin verification

### DIFF
--- a/tidewave-core/src/server.rs
+++ b/tidewave-core/src/server.rs
@@ -543,7 +543,7 @@ async fn proxy_handler(
 
 async fn about() -> Json<AboutResponse> {
     Json(AboutResponse {
-        name: "tidewave-app".to_string(),
+        name: "tidewave-cli".to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
     })
 }


### PR DESCRIPTION
This will allow us to change the `/tidewave` route in frameworks to automatically redirect to the app.