### PR TITLE
wip: Add "View Logs" button to error dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5054,6 +5054,7 @@ dependencies = [
  "tokio",
  "toml 0.8.2",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -5419,6 +5420,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
 toml = "0.8"
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]


### PR DESCRIPTION
I'm opening this as a wip because at the moment I don't think we're logging any useful information, i.e. when we fail we're calling `error!(...)` which would log but we're also displaying error dialog so logging is redundant. This could be more useful for http server logging, however.

Demo:

(Started with `--debug`)

<img width="249" height="211" alt="image" src="https://github.com/user-attachments/assets/0290275f-f0ac-4d88-bd99-31f88fcf29f6" />

<img width="1352" height="793" alt="image" src="https://github.com/user-attachments/assets/85906149-0959-47fa-9c59-f49403dd8d59" />

<img width="372" height="346" alt="image" src="https://github.com/user-attachments/assets/a7dff781-ec7a-4284-a459-441eb4831ff2" />