### PR TITLE
ci: add xdg-utils in ubuntu-22.04-arm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,8 @@ jobs:
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
-            patchelf
+            patchelf \
+            xdg-utils
 
       - name: Install Tauri CLI
         shell: bash


### PR DESCRIPTION
This should fix the failing nightly release of ARM linux.

I have tested this on my branch : https://github.com/bu6n/tidewave_app/actions/runs/19322191998/job/55265637271#step:8:702

The release is still failing because of missing signing keys, but I think this means the AppImage was successfully created.