### PR TITLE
Check for WSL after path resolution on write

### DIFF
--- a/tidewave-core/src/server.rs
+++ b/tidewave-core/src/server.rs
@@ -574,12 +574,6 @@ async fn write_file_handler(
 async fn stat_file_handler(
     Query(query): Query<StatFileParams>,
 ) -> Result<Json<StatFileResponse>, StatusCode> {
-    let path = Path::new(&query.path);
-
-    if !path.is_absolute() {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-
     #[cfg(target_os = "windows")]
     let file_path = if query.is_wsl {
         match wslpath_to_windows(&query.path).await {
@@ -597,6 +591,10 @@ async fn stat_file_handler(
 
     #[cfg(not(target_os = "windows"))]
     let file_path = query.path.clone();
+
+    if !Path::new(&file_path).is_absolute() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
 
     let mtime_op = fetch_mtime(file_path);
 


### PR DESCRIPTION
A user reported that reads were working on WSL but not writes, which failed 400. The only possible cause is the wrong order.