### PR TITLE
fix xdg-open in appimage

### DIFF
--- a/tidewave-core/src/lib.rs
+++ b/tidewave-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod acp_proxy;
 mod command;
+pub use command::cleanup_appimage_env;
 pub mod config;
 mod http_handlers;
 mod mcp_remote;


### PR DESCRIPTION
This resolves https://github.com/tauri-apps/tauri/issues/10078 by running `xdg-open` directly, making sure that we unset any appimage specific environment variable changes.

Without this change, all the menu buttons that try to open a window don't work on Fedora for me.

Closes https://github.com/tidewave-ai/tidewave_app/issues/62.