### PR TITLE
Only serve OFFLINE_HTML on /

### DIFF
--- a/tidewave-core/src/server.rs
+++ b/tidewave-core/src/server.rs
@@ -1448,7 +1448,7 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
-  if (event.request.mode === 'navigate') {
+  if (event.request.mode === 'navigate' && new URL(event.request.url).pathname === '/') {
     event.respondWith(
       fetch(event.request).catch(() => new Response(OFFLINE_HTML, {
         headers: { 'Content-Type': 'text/html' }


### PR DESCRIPTION
I suspect that we were serving HTML for the
service worker when the computer goes to sleep
which causes the page to refresh.