### PR TITLE
Automatically ignore gitignored files on fs events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +949,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1891,6 +1920,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2350,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -5358,6 +5416,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "hyper",
+ "ignore",
  "libc",
  "notify",
  "portable-pty",

--- a/tidewave-core/Cargo.toml
+++ b/tidewave-core/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4", features = ["derive"] }
 toml = "0.8"
 dashmap = "6.0"
 notify = "8.1"
+ignore = "0.4"
 uuid = { version = "1.11", features = ["v4", "serde"] }
 anyhow = "1.0"
 tar = "0.4"

--- a/tidewave-core/src/ws/watch.rs
+++ b/tidewave-core/src/ws/watch.rs
@@ -8,10 +8,11 @@
 //! Event paths (created, modified, deleted, renamed) are relative to the watched directory.
 
 use dashmap::DashMap;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify::{EventKind, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use std::{
-    path::Path,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -303,7 +304,10 @@ fn init_watcher(
             }
         };
 
-        if let Err(e) = watcher.watch(Path::new(&canonical_path), RecursiveMode::Recursive) {
+        let root_path = PathBuf::from(&canonical_path);
+        let gitignore_path = root_path.join(".gitignore");
+
+        if let Err(e) = watcher.watch(&root_path, RecursiveMode::Recursive) {
             let _ = tx.send(WatchEvent::Terminated {
                 error: format!("Failed to watch path: {}", e),
             });
@@ -311,6 +315,7 @@ fn init_watcher(
             return;
         }
 
+        let mut gitignore = build_gitignore(&root_path);
         let mut pending_rename_from: Option<String> = None;
         let cleanup_check_interval = Duration::from_secs(30);
 
@@ -319,6 +324,11 @@ fn init_watcher(
                 res = notify_rx.recv() => {
                     match res {
                         Some(Ok(event)) => {
+                            let gitignore_changed = event
+                                .paths
+                                .iter()
+                                .any(|p| p == &gitignore_path);
+
                             let watch_events = convert_notify_event(
                                 event,
                                 &canonical_path,
@@ -328,12 +338,22 @@ fn init_watcher(
                             for watch_event in watch_events {
                                 let is_terminated = matches!(&watch_event, WatchEvent::Terminated { .. });
 
-                                let _ = tx.send(watch_event);
+                                if let Some(filtered) = filter_event_for_gitignore(
+                                    watch_event,
+                                    &gitignore,
+                                    &root_path,
+                                ) {
+                                    let _ = tx.send(filtered);
+                                }
 
                                 if is_terminated {
                                     state.watchers.remove(&canonical_path);
                                     return;
                                 }
+                            }
+
+                            if gitignore_changed {
+                                gitignore = build_gitignore(&root_path);
                             }
                         }
                         Some(Err(e)) => {
@@ -369,6 +389,74 @@ fn to_relative_path(absolute_path: &Path, watched_path: &str) -> Option<String> 
         .strip_prefix(watched)
         .ok()
         .map(|p| p.to_string_lossy().to_string())
+}
+
+/// Build a `Gitignore` matcher from `<root>/.gitignore`. Returns an empty
+/// matcher if the file is missing or unreadable.
+fn build_gitignore(root: &Path) -> Gitignore {
+    let gitignore_path = root.join(".gitignore");
+    if !gitignore_path.exists() {
+        return Gitignore::empty();
+    }
+    let mut builder = GitignoreBuilder::new(root);
+    if let Some(err) = builder.add(&gitignore_path) {
+        warn!("Failed to read .gitignore at {:?}: {}", gitignore_path, err);
+        return Gitignore::empty();
+    }
+    builder.build().unwrap_or_else(|err| {
+        warn!("Failed to build gitignore matcher for {:?}: {}", root, err);
+        Gitignore::empty()
+    })
+}
+
+/// Check whether a path (relative to the watched root) should be ignored.
+fn is_path_ignored(gitignore: &Gitignore, relative_path: &str, root: &Path) -> bool {
+    if relative_path.is_empty() {
+        return false;
+    }
+    let abs = root.join(relative_path);
+    let is_dir = abs.is_dir();
+    if gitignore
+        .matched_path_or_any_parents(relative_path, is_dir)
+        .is_ignore()
+    {
+        return true;
+    }
+    // For paths that no longer exist (e.g. deletions) we don't know whether
+    // the path was a directory. Try the directory interpretation as well so
+    // that patterns like `target/` still match a deleted `target` directory.
+    if !is_dir && !abs.exists() {
+        return gitignore
+            .matched_path_or_any_parents(relative_path, true)
+            .is_ignore();
+    }
+    false
+}
+
+/// Filter a `WatchEvent` through the gitignore matcher. Returns `None` if any
+/// path in the event is ignored; the original event is otherwise mirrored
+/// through unchanged.
+fn filter_event_for_gitignore(
+    event: WatchEvent,
+    gitignore: &Gitignore,
+    root: &Path,
+) -> Option<WatchEvent> {
+    let fs_event = match event {
+        WatchEvent::FS(fs) => fs,
+        other => return Some(other),
+    };
+
+    let keep = match &fs_event {
+        FsEvent::Warning { .. } => true,
+        FsEvent::Created { path }
+        | FsEvent::Modified { path }
+        | FsEvent::Deleted { path } => !is_path_ignored(gitignore, path, root),
+        FsEvent::Renamed { from, to } => {
+            !is_path_ignored(gitignore, from, root) && !is_path_ignored(gitignore, to, root)
+        }
+    };
+
+    keep.then_some(WatchEvent::FS(fs_event))
 }
 
 fn convert_notify_event(

--- a/tidewave-core/src/ws/watch.rs
+++ b/tidewave-core/src/ws/watch.rs
@@ -75,11 +75,16 @@ pub struct ActiveWatch {
     pub started: AtomicBool,
 }
 
+/// Key identifying a watcher: the canonical path plus a flag for whether the
+/// root `.gitignore` is honored. Different flag values get different watchers
+/// so each can broadcast events appropriate for its mode.
+pub type WatcherKey = (String, bool);
+
 /// Watch feature state
 #[derive(Clone, Default)]
 pub struct WatchFeatureState {
-    /// Active watchers (canonical_path → active_watch)
-    pub watchers: Arc<DashMap<String, Arc<ActiveWatch>>>,
+    /// Active watchers ((canonical_path, respect_gitignore) → active_watch)
+    pub watchers: Arc<DashMap<WatcherKey, Arc<ActiveWatch>>>,
 }
 
 impl WatchFeatureState {
@@ -99,6 +104,9 @@ struct JoinPayload {
     path: String,
     #[serde(default)]
     is_wsl: bool,
+    /// When true, drop events for paths matched by the root `.gitignore`.
+    #[serde(default)]
+    respect_gitignore: bool,
 }
 
 /// Initialize a `watch:<ref>` channel.
@@ -142,10 +150,14 @@ pub async fn init(
         Err(e) => return InitResult::Error(format!("Failed to canonicalize path: {}", e)),
     };
 
+    // Watchers are keyed by (canonical_path, respect_gitignore) so clients
+    // requesting different filtering modes get different broadcasters.
+    let key: WatcherKey = (canonical_path.clone(), payload.respect_gitignore);
+
     // Get or create active watch entry (atomic via entry API)
     let active_watch = state
         .watchers
-        .entry(canonical_path.clone())
+        .entry(key.clone())
         .or_insert_with(|| {
             let (tx, _rx) = broadcast::channel::<WatchEvent>(256);
             Arc::new(ActiveWatch {
@@ -165,7 +177,7 @@ pub async fn init(
         .is_ok();
 
     if should_start_watcher {
-        init_watcher(&state, &active_watch, &canonical_path, payload.is_wsl);
+        init_watcher(&state, &active_watch, &key, payload.is_wsl);
     }
 
     // Send success reply
@@ -204,17 +216,21 @@ pub async fn init(
     }
 }
 
-/// Spawn the filesystem watcher task for a canonical path.
+/// Spawn the filesystem watcher task for a watcher key.
 /// Broadcasts `WatchEvent`s to all subscribers via the `ActiveWatch` broadcast channel.
+/// When `respect_gitignore` is true (encoded in the key), events for paths
+/// matched by `<root>/.gitignore` are dropped before broadcasting.
 /// Cleans itself up from `state.watch.watchers` when done.
 fn init_watcher(
     state: &WatchFeatureState,
     active_watch: &Arc<ActiveWatch>,
-    canonical_path: &str,
+    key: &WatcherKey,
     is_wsl: bool,
 ) {
     let tx = active_watch.tx.clone();
-    let canonical_path = canonical_path.to_string();
+    let key = key.clone();
+    let canonical_path = key.0.clone();
+    let respect_gitignore = key.1;
     let state = state.clone();
 
     // On Windows with WSL, use poll watcher directly since native watcher
@@ -254,7 +270,7 @@ fn init_watcher(
                     let _ = tx.send(WatchEvent::Terminated {
                         error: format!("Failed to create poll watcher: {}", e),
                     });
-                    state.watchers.remove(&canonical_path);
+                    state.watchers.remove(&key);
                     return;
                 }
             }
@@ -296,7 +312,7 @@ fn init_watcher(
                                     e, poll_err
                                 ),
                             });
-                            state.watchers.remove(&canonical_path);
+                            state.watchers.remove(&key);
                             return;
                         }
                     }
@@ -311,11 +327,15 @@ fn init_watcher(
             let _ = tx.send(WatchEvent::Terminated {
                 error: format!("Failed to watch path: {}", e),
             });
-            state.watchers.remove(&canonical_path);
+            state.watchers.remove(&key);
             return;
         }
 
-        let mut gitignore = build_gitignore(&root_path);
+        let mut gitignore = if respect_gitignore {
+            Some(build_gitignore(&root_path))
+        } else {
+            None
+        };
         let mut pending_rename_from: Option<String> = None;
         let cleanup_check_interval = Duration::from_secs(30);
 
@@ -324,10 +344,8 @@ fn init_watcher(
                 res = notify_rx.recv() => {
                     match res {
                         Some(Ok(event)) => {
-                            let gitignore_changed = event
-                                .paths
-                                .iter()
-                                .any(|p| p == &gitignore_path);
+                            let gitignore_changed = gitignore.is_some()
+                                && event.paths.iter().any(|p| p == &gitignore_path);
 
                             let watch_events = convert_notify_event(
                                 event,
@@ -338,33 +356,40 @@ fn init_watcher(
                             for watch_event in watch_events {
                                 let is_terminated = matches!(&watch_event, WatchEvent::Terminated { .. });
 
-                                if let Some(filtered) = filter_event_for_gitignore(
-                                    watch_event,
-                                    &gitignore,
-                                    &root_path,
-                                ) {
-                                    let _ = tx.send(filtered);
+                                let to_send = match &gitignore {
+                                    Some(gi) => filter_event_for_gitignore(
+                                        watch_event,
+                                        gi,
+                                        &root_path,
+                                    ),
+                                    None => Some(watch_event),
+                                };
+
+                                if let Some(event) = to_send {
+                                    let _ = tx.send(event);
                                 }
 
                                 if is_terminated {
-                                    state.watchers.remove(&canonical_path);
+                                    state.watchers.remove(&key);
                                     return;
                                 }
                             }
 
                             if gitignore_changed {
-                                gitignore = build_gitignore(&root_path);
+                                if let Some(gi) = gitignore.as_mut() {
+                                    *gi = build_gitignore(&root_path);
+                                }
                             }
                         }
                         Some(Err(e)) => {
                             let _ = tx.send(WatchEvent::Terminated {
                                 error: format!("Watch error: {}", e),
                             });
-                            state.watchers.remove(&canonical_path);
+                            state.watchers.remove(&key);
                             return;
                         }
                         None => {
-                            state.watchers.remove(&canonical_path);
+                            state.watchers.remove(&key);
                             return;
                         }
                     }
@@ -372,7 +397,7 @@ fn init_watcher(
                 _ = tokio::time::sleep(cleanup_check_interval) => {
                     if tx.receiver_count() == 0 {
                         debug!("No subscribers remaining for watch on {}, cleaning up", canonical_path);
-                        state.watchers.remove(&canonical_path);
+                        state.watchers.remove(&key);
                         return;
                     }
                 }

--- a/tidewave-core/src/ws/watch.rs
+++ b/tidewave-core/src/ws/watch.rs
@@ -78,6 +78,12 @@ pub struct ActiveWatch {
 /// Key identifying a watcher: the canonical path plus a flag for whether the
 /// root `.gitignore` is honored. Different flag values get different watchers
 /// so each can broadcast events appropriate for its mode.
+///
+/// Note: `global_gitignores` (see [`JoinPayload`]) is intentionally **not**
+/// part of the key. Callers are expected to pass a consistent list across all
+/// joins with `respect_gitignore = true` for the same path; the first joiner
+/// initializes the matcher and later joiners share that watcher regardless of
+/// what they pass.
 pub type WatcherKey = (String, bool);
 
 /// Watch feature state
@@ -104,9 +110,20 @@ struct JoinPayload {
     path: String,
     #[serde(default)]
     is_wsl: bool,
-    /// When true, drop events for paths matched by the root `.gitignore`.
+    /// When true, drop events for paths matched by the root `.gitignore`
+    /// and any `global_gitignores` files.
     #[serde(default)]
     respect_gitignore: bool,
+    /// Absolute paths to additional gitignore files (e.g. user-global
+    /// excludes). Loaded once at watcher start; assumed not to change.
+    ///
+    /// Ignored when `respect_gitignore` is false. When `respect_gitignore` is
+    /// true, callers are expected to **always** pass this list and to pass
+    /// the **same** list across all watchers for a given path: the field is
+    /// not part of the watcher dedup key, so the first joiner's list is what
+    /// every subsequent joiner will see.
+    #[serde(default)]
+    global_gitignores: Vec<String>,
 }
 
 /// Initialize a `watch:<ref>` channel.
@@ -177,7 +194,13 @@ pub async fn init(
         .is_ok();
 
     if should_start_watcher {
-        init_watcher(&state, &active_watch, &key, payload.is_wsl);
+        init_watcher(
+            &state,
+            &active_watch,
+            &key,
+            payload.is_wsl,
+            payload.global_gitignores,
+        );
     }
 
     // Send success reply
@@ -219,13 +242,15 @@ pub async fn init(
 /// Spawn the filesystem watcher task for a watcher key.
 /// Broadcasts `WatchEvent`s to all subscribers via the `ActiveWatch` broadcast channel.
 /// When `respect_gitignore` is true (encoded in the key), events for paths
-/// matched by `<root>/.gitignore` are dropped before broadcasting.
+/// matched by `<root>/.gitignore` and any `global_gitignores` files are dropped
+/// before broadcasting. `global_gitignores` is unused when the flag is false.
 /// Cleans itself up from `state.watch.watchers` when done.
 fn init_watcher(
     state: &WatchFeatureState,
     active_watch: &Arc<ActiveWatch>,
     key: &WatcherKey,
     is_wsl: bool,
+    global_gitignores: Vec<String>,
 ) {
     let tx = active_watch.tx.clone();
     let key = key.clone();
@@ -332,7 +357,7 @@ fn init_watcher(
         }
 
         let mut gitignore = if respect_gitignore {
-            Some(build_gitignore(&root_path))
+            Some(build_gitignore(&root_path, &global_gitignores))
         } else {
             None
         };
@@ -377,7 +402,7 @@ fn init_watcher(
 
                             if gitignore_changed {
                                 if let Some(gi) = gitignore.as_mut() {
-                                    *gi = build_gitignore(&root_path);
+                                    *gi = build_gitignore(&root_path, &global_gitignores);
                                 }
                             }
                         }
@@ -416,18 +441,26 @@ fn to_relative_path(absolute_path: &Path, watched_path: &str) -> Option<String> 
         .map(|p| p.to_string_lossy().to_string())
 }
 
-/// Build a `Gitignore` matcher from `<root>/.gitignore`. Returns an empty
-/// matcher if the file is missing or unreadable.
-fn build_gitignore(root: &Path) -> Gitignore {
-    let gitignore_path = root.join(".gitignore");
-    if !gitignore_path.exists() {
-        return Gitignore::empty();
-    }
+/// Build a `Gitignore` matcher anchored at `root`, combining any external
+/// `globals` files (loaded once, in order) with `<root>/.gitignore`. Globals
+/// are added first so the per-watch `.gitignore` can override them via `!`
+/// patterns (last-match-wins, matching git's precedence).
+fn build_gitignore(root: &Path, globals: &[String]) -> Gitignore {
     let mut builder = GitignoreBuilder::new(root);
-    if let Some(err) = builder.add(&gitignore_path) {
-        warn!("Failed to read .gitignore at {:?}: {}", gitignore_path, err);
-        return Gitignore::empty();
+
+    for global in globals {
+        if let Some(err) = builder.add(global) {
+            warn!("Failed to read global gitignore {}: {}", global, err);
+        }
     }
+
+    let gitignore_path = root.join(".gitignore");
+    if gitignore_path.exists() {
+        if let Some(err) = builder.add(&gitignore_path) {
+            warn!("Failed to read .gitignore at {:?}: {}", gitignore_path, err);
+        }
+    }
+
     builder.build().unwrap_or_else(|err| {
         warn!("Failed to build gitignore matcher for {:?}: {}", root, err);
         Gitignore::empty()

--- a/tidewave-core/tests/watch_tests.rs
+++ b/tidewave-core/tests/watch_tests.rs
@@ -330,6 +330,105 @@ async fn test_watch_concurrent_subscribers() {
 }
 
 #[tokio::test]
+async fn test_watch_gitignore_filters_files_and_directories() {
+    let state = WsState::new();
+    let (ws_out_tx, mut ws_out_rx, ws_in_tx, ws_in_rx) = create_fake_phoenix_socket();
+    let websocket_id = uuid::Uuid::new_v4();
+
+    // Ignore `*.log` (file pattern) and `target/` (directory pattern).
+    let temp_dir = tempfile::tempdir().unwrap();
+    tokio::fs::write(temp_dir.path().join(".gitignore"), "*.log\ntarget/\n")
+        .await
+        .unwrap();
+    let target_dir = temp_dir.path().join("target");
+    tokio::fs::create_dir(&target_dir).await.unwrap();
+
+    let watch_path = temp_dir.path().to_string_lossy().to_string();
+
+    tokio::spawn(async move {
+        unit_testable_ws_handler(ws_out_tx, ws_in_rx, state, websocket_id).await;
+    });
+
+    let reply = join_watch(&ws_in_tx, &mut ws_out_rx, "ignore_watch", &watch_path).await;
+    assert_eq!(reply.payload.as_json()["status"], "ok");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Both ignored writes (file pattern + directory pattern) should be
+    // dropped; only the non-ignored file should produce an event.
+    tokio::fs::write(temp_dir.path().join("debug.log"), "ignored")
+        .await
+        .unwrap();
+    tokio::fs::write(target_dir.join("artifact.bin"), "ignored")
+        .await
+        .unwrap();
+    tokio::fs::write(temp_dir.path().join("keep.txt"), "kept")
+        .await
+        .unwrap();
+
+    let event = wait_for_event(&mut ws_out_rx, "created", 2000).await;
+    assert!(event.is_some(), "Expected created event for keep.txt");
+    let event = event.unwrap();
+    assert_eq!(event.payload.as_json()["path"].as_str().unwrap(), "keep.txt");
+}
+
+#[tokio::test]
+async fn test_watch_gitignore_reload() {
+    let state = WsState::new();
+    let (ws_out_tx, mut ws_out_rx, ws_in_tx, ws_in_rx) = create_fake_phoenix_socket();
+    let websocket_id = uuid::Uuid::new_v4();
+
+    // Initially ignore *.log
+    let temp_dir = tempfile::tempdir().unwrap();
+    let gitignore = temp_dir.path().join(".gitignore");
+    tokio::fs::write(&gitignore, "*.log\n").await.unwrap();
+
+    let watch_path = temp_dir.path().to_string_lossy().to_string();
+
+    tokio::spawn(async move {
+        unit_testable_ws_handler(ws_out_tx, ws_in_rx, state, websocket_id).await;
+    });
+
+    let reply = join_watch(&ws_in_tx, &mut ws_out_rx, "reload_watch", &watch_path).await;
+    assert_eq!(reply.payload.as_json()["status"], "ok");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Rewrite .gitignore so *.log is no longer ignored. The change to the
+    // .gitignore file itself must pass through (it's not in the ignore set),
+    // and trigger a matcher reload.
+    tokio::fs::write(&gitignore, "*.tmp\n").await.unwrap();
+
+    // Drain the .gitignore modification event so it doesn't confuse later
+    // assertions.
+    let _ = wait_for_event(&mut ws_out_rx, "modified", 2000).await;
+
+    // Give the reload a moment to settle (it happens after the event is
+    // processed, on the next iteration of the watcher loop).
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Now create a *.log (should pass through since *.log is no longer
+    // ignored) and a *.tmp (should be filtered).
+    tokio::fs::write(temp_dir.path().join("scratch.tmp"), "ignored")
+        .await
+        .unwrap();
+    tokio::fs::write(temp_dir.path().join("debug.log"), "kept")
+        .await
+        .unwrap();
+
+    let event = wait_for_event(&mut ws_out_rx, "created", 2000).await;
+    assert!(
+        event.is_some(),
+        "Expected created event for debug.log after reload"
+    );
+    let event = event.unwrap();
+    assert_eq!(
+        event.payload.as_json()["path"].as_str().unwrap(),
+        "debug.log"
+    );
+}
+
+#[tokio::test]
 async fn test_watch_subdirectory_events() {
     let state = WsState::new();
     let (ws_out_tx, mut ws_out_rx, ws_in_tx, ws_in_rx) = create_fake_phoenix_socket();

--- a/tidewave-core/tests/watch_tests.rs
+++ b/tidewave-core/tests/watch_tests.rs
@@ -397,6 +397,55 @@ async fn test_watch_gitignore_filters_files_and_directories() {
 }
 
 #[tokio::test]
+async fn test_watch_global_gitignores_are_honored() {
+    let state = WsState::new();
+    let (ws_out_tx, mut ws_out_rx, ws_in_tx, ws_in_rx) = create_fake_phoenix_socket();
+    let websocket_id = uuid::Uuid::new_v4();
+
+    // Watched dir has no local .gitignore. The ignore patterns come entirely
+    // from an external file living outside the watched tree.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let globals_dir = tempfile::tempdir().unwrap();
+    let global_gitignore = globals_dir.path().join("global_excludes");
+    tokio::fs::write(&global_gitignore, "*.log\n").await.unwrap();
+
+    let watch_path = temp_dir.path().to_string_lossy().to_string();
+    let global_path = global_gitignore.to_string_lossy().to_string();
+
+    tokio::spawn(async move {
+        unit_testable_ws_handler(ws_out_tx, ws_in_rx, state, websocket_id).await;
+    });
+
+    let reply = join_watch_with_payload(
+        &ws_in_tx,
+        &mut ws_out_rx,
+        "global_watch",
+        json!({
+            "path": watch_path,
+            "respect_gitignore": true,
+            "global_gitignores": [global_path],
+        }),
+    )
+    .await;
+    assert_eq!(reply.payload.as_json()["status"], "ok");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // *.log is filtered by the global; sibling file passes through.
+    tokio::fs::write(temp_dir.path().join("debug.log"), "ignored")
+        .await
+        .unwrap();
+    tokio::fs::write(temp_dir.path().join("keep.txt"), "kept")
+        .await
+        .unwrap();
+
+    let event = wait_for_event(&mut ws_out_rx, "created", 2000).await;
+    assert!(event.is_some(), "Expected created event for keep.txt");
+    let event = event.unwrap();
+    assert_eq!(event.payload.as_json()["path"].as_str().unwrap(), "keep.txt");
+}
+
+#[tokio::test]
 async fn test_watch_gitignore_reload() {
     let state = WsState::new();
     let (ws_out_tx, mut ws_out_rx, ws_in_tx, ws_in_rx) = create_fake_phoenix_socket();

--- a/tidewave-core/tests/watch_tests.rs
+++ b/tidewave-core/tests/watch_tests.rs
@@ -30,6 +30,24 @@ async fn join_watch(
         .expect("Expected phx_reply for join")
 }
 
+/// Same as `join_watch` but allows specifying the full join payload
+/// (e.g. to set `respect_gitignore`).
+async fn join_watch_with_payload(
+    ws_in_tx: &futures_mpsc::UnboundedSender<Result<axum::extract::ws::Message, axum::Error>>,
+    ws_out_rx: &mut futures_mpsc::UnboundedReceiver<axum::extract::ws::Message>,
+    reference: &str,
+    payload: serde_json::Value,
+) -> PhxMessage {
+    send_phoenix_msg(
+        ws_in_tx,
+        &PhxMessage::new(format!("watch:{}", reference), events::PHX_JOIN, payload).with_ref("1"),
+    );
+
+    wait_for_reply(ws_out_rx, 1000)
+        .await
+        .expect("Expected phx_reply for join")
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -349,7 +367,13 @@ async fn test_watch_gitignore_filters_files_and_directories() {
         unit_testable_ws_handler(ws_out_tx, ws_in_rx, state, websocket_id).await;
     });
 
-    let reply = join_watch(&ws_in_tx, &mut ws_out_rx, "ignore_watch", &watch_path).await;
+    let reply = join_watch_with_payload(
+        &ws_in_tx,
+        &mut ws_out_rx,
+        "ignore_watch",
+        json!({"path": watch_path, "respect_gitignore": true}),
+    )
+    .await;
     assert_eq!(reply.payload.as_json()["status"], "ok");
 
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -389,7 +413,13 @@ async fn test_watch_gitignore_reload() {
         unit_testable_ws_handler(ws_out_tx, ws_in_rx, state, websocket_id).await;
     });
 
-    let reply = join_watch(&ws_in_tx, &mut ws_out_rx, "reload_watch", &watch_path).await;
+    let reply = join_watch_with_payload(
+        &ws_in_tx,
+        &mut ws_out_rx,
+        "reload_watch",
+        json!({"path": watch_path, "respect_gitignore": true}),
+    )
+    .await;
     assert_eq!(reply.payload.as_json()["status"], "ok");
 
     tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
This reduces the amount of data over the socket.

@SteffenDE @jonatanklosko we are doing it by default, should it be opt-in instead?