### PR TITLE
Use wsl_distro instead of is_wsl

### DIFF
--- a/tidewave-core/src/command.rs
+++ b/tidewave-core/src/command.rs
@@ -132,11 +132,11 @@ pub fn create_shell_command(
     cmd: &str,
     env: HashMap<String, String>,
     cwd: &str,
-    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] is_wsl: bool,
+    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] wsl_distro: Option<&str>,
 ) -> Command {
     #[cfg(target_os = "windows")]
     {
-        if is_wsl {
+        if let Some(distro) = wsl_distro {
             let env_prefix = wsl_env_assignments(&env);
             let full_command = if env_prefix.is_empty() {
                 cmd.to_string()
@@ -146,6 +146,8 @@ pub fn create_shell_command(
 
             let mut command = command_with_limited_env("wsl.exe");
             command
+                .arg("-d")
+                .arg(distro)
                 .arg("--cd")
                 .arg(cwd)
                 .arg("sh")
@@ -199,14 +201,14 @@ pub fn create_cmd_command(
     args: &[String],
     env: HashMap<String, String>,
     cwd: &str,
-    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] is_wsl: bool,
+    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] wsl_distro: Option<&str>,
 ) -> Command {
     #[cfg(target_os = "windows")]
     {
-        if is_wsl {
+        if let Some(distro) = wsl_distro {
             let env_assignments = wsl_env_assignments(&env);
             let mut command = command_with_limited_env("wsl.exe");
-            command.arg("--cd").arg(cwd);
+            command.arg("-d").arg(distro).arg("--cd").arg(cwd);
             if !env_assignments.is_empty() {
                 command.arg("env");
                 for assignment in &env_assignments {

--- a/tidewave-core/src/http_handlers.rs
+++ b/tidewave-core/src/http_handlers.rs
@@ -112,7 +112,7 @@ pub struct DownloadParams {
     #[serde(default)]
     pub extract: Option<String>, // Optional path to extract from archive (for .tar.gz/.tgz files)
     #[serde(default)]
-    pub is_wsl: bool, // If true, convert the final path to WSL format using wslpath
+    pub wsl_distro: Option<String>, // If Some, convert the final path to WSL format using wslpath in that distro
 }
 
 #[derive(Serialize, Clone)]
@@ -242,7 +242,7 @@ pub async fn download_handler(
     let throttle = params.throttle;
     let executable = params.executable;
     let extract = params.extract;
-    let is_wsl = params.is_wsl;
+    let wsl_distro = params.wsl_distro;
 
     // Validate key to prevent path traversal attacks
     if key.contains('/') || key.contains('\\') || key.contains(':') || key.contains("..") {
@@ -381,12 +381,14 @@ pub async fn download_handler(
             return;
         }
 
-        let final_path = if is_wsl {
+        let final_path = if let Some(distro) = wsl_distro.as_deref() {
             // Convert Windows path to WSL path using wslpath
             #[cfg(target_os = "windows")]
             {
                 let windows_path = file_path_for_stream.display().to_string();
                 match tokio::process::Command::new("wsl.exe")
+                    .arg("-d")
+                    .arg(distro)
                     .arg("-e")
                     .arg("wslpath")
                     .arg("-a")
@@ -410,6 +412,7 @@ pub async fn download_handler(
             }
             #[cfg(not(target_os = "windows"))]
             {
+                let _ = distro;
                 file_path_for_stream.display().to_string()
             }
         } else {

--- a/tidewave-core/src/server.rs
+++ b/tidewave-core/src/server.rs
@@ -35,8 +35,7 @@ struct ShellParams {
     cwd: Option<String>,
     env: Option<HashMap<String, String>>,
     #[serde(default)]
-    #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -47,40 +46,35 @@ struct CmdParams {
     cwd: Option<String>,
     env: Option<HashMap<String, String>>,
     #[serde(default)]
-    #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct StatParams {
     path: String,
     #[serde(default)]
-    #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct ListDirParams {
     path: String,
     #[serde(default)]
-    #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct MkdirParams {
     path: String,
     #[serde(default)]
-    #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct ReadFileParams {
     path: String,
     #[serde(default)]
-    #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -90,16 +84,14 @@ struct WriteFileParams {
     #[serde(default)]
     exclusive: bool,
     #[serde(default)]
-    #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct DeleteFileParams {
     path: String,
     #[serde(default)]
-    #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -107,8 +99,7 @@ struct CopyParams {
     from_path: String,
     to_path: String,
     #[serde(default)]
-    #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -116,8 +107,7 @@ struct MoveParams {
     from_path: String,
     to_path: String,
     #[serde(default)]
-    #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -128,7 +118,7 @@ struct WhichParams {
     env: Option<HashMap<String, String>>,
     #[serde(default)]
     #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -142,7 +132,7 @@ struct OpenParams {
 struct AboutParams {
     #[serde(default)]
     #[allow(dead_code)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -611,7 +601,8 @@ async fn shell_handler(
     let cwd = payload.cwd.unwrap_or(".".to_string());
     let env = payload.env.unwrap_or_else(|| std::env::vars().collect());
 
-    let mut command = create_shell_command(&payload.command, env, &cwd, payload.is_wsl);
+    let mut command =
+        create_shell_command(&payload.command, env, &cwd, payload.wsl_distro.as_deref());
     command
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -630,7 +621,13 @@ async fn cmd_handler(
     let env = payload.env.unwrap_or_else(|| std::env::vars().collect());
     let args = payload.args.unwrap_or_default();
 
-    let mut command = create_cmd_command(&payload.command, &args, env, &cwd, payload.is_wsl);
+    let mut command = create_cmd_command(
+        &payload.command,
+        &args,
+        env,
+        &cwd,
+        payload.wsl_distro.as_deref(),
+    );
     command
         .stdin(if payload.input.is_some() {
             Stdio::piped()
@@ -751,7 +748,7 @@ fn create_status_chunk(status: i32) -> Bytes {
 async fn read_file_handler(
     Json(payload): Json<ReadFileParams>,
 ) -> Result<Json<ReadFileResponse>, StatusCode> {
-    let file_path = match normalize_path(&payload.path, payload.is_wsl).await {
+    let file_path = match normalize_path(&payload.path, payload.wsl_distro.as_deref()).await {
         Ok(path) => path,
         Err(error) => {
             return Ok(Json(ReadFileResponse::ReadFileResponseErr {
@@ -790,7 +787,7 @@ async fn read_file_handler(
 async fn write_file_handler(
     Json(payload): Json<WriteFileParams>,
 ) -> Result<Json<WriteFileResponse>, StatusCode> {
-    let file_path = match normalize_path(&payload.path, payload.is_wsl).await {
+    let file_path = match normalize_path(&payload.path, payload.wsl_distro.as_deref()).await {
         Ok(path) => path,
         Err(error) => {
             return Ok(Json(WriteFileResponse::WriteFileResponseErr {
@@ -863,7 +860,7 @@ async fn write_file_handler(
 async fn delete_file_handler(
     Json(payload): Json<DeleteFileParams>,
 ) -> Result<Json<DeleteFileResponse>, StatusCode> {
-    let file_path = match normalize_path(&payload.path, payload.is_wsl).await {
+    let file_path = match normalize_path(&payload.path, payload.wsl_distro.as_deref()).await {
         Ok(path) => path,
         Err(error) => {
             return Ok(Json(DeleteFileResponse::DeleteFileResponseErr {
@@ -891,7 +888,7 @@ async fn delete_file_handler(
 }
 
 async fn copy_handler(Json(payload): Json<CopyParams>) -> Result<Json<CopyResponse>, StatusCode> {
-    let from_path = match normalize_path(&payload.from_path, payload.is_wsl).await {
+    let from_path = match normalize_path(&payload.from_path, payload.wsl_distro.as_deref()).await {
         Ok(path) => path,
         Err(error) => {
             return Ok(Json(CopyResponse::CopyResponseErr {
@@ -901,7 +898,7 @@ async fn copy_handler(Json(payload): Json<CopyParams>) -> Result<Json<CopyRespon
         }
     };
 
-    let to_path = match normalize_path(&payload.to_path, payload.is_wsl).await {
+    let to_path = match normalize_path(&payload.to_path, payload.wsl_distro.as_deref()).await {
         Ok(path) => path,
         Err(error) => {
             return Ok(Json(CopyResponse::CopyResponseErr {
@@ -929,7 +926,7 @@ async fn copy_handler(Json(payload): Json<CopyParams>) -> Result<Json<CopyRespon
 }
 
 async fn move_handler(Json(payload): Json<MoveParams>) -> Result<Json<MoveResponse>, StatusCode> {
-    let from_path = match normalize_path(&payload.from_path, payload.is_wsl).await {
+    let from_path = match normalize_path(&payload.from_path, payload.wsl_distro.as_deref()).await {
         Ok(path) => path,
         Err(error) => {
             return Ok(Json(MoveResponse::MoveResponseErr {
@@ -939,7 +936,7 @@ async fn move_handler(Json(payload): Json<MoveParams>) -> Result<Json<MoveRespon
         }
     };
 
-    let to_path = match normalize_path(&payload.to_path, payload.is_wsl).await {
+    let to_path = match normalize_path(&payload.to_path, payload.wsl_distro.as_deref()).await {
         Ok(path) => path,
         Err(error) => {
             return Ok(Json(MoveResponse::MoveResponseErr {
@@ -1003,7 +1000,7 @@ async fn open_handler(Json(payload): Json<OpenParams>) -> Result<StatusCode, Sta
         #[cfg(target_os = "linux")]
         {
             if env::var("WSL_DISTRO_NAME").is_ok() {
-                let win_path = wslpath_to_windows(&payload.path).await.map_err(|e| {
+                let win_path = wslpath_to_windows(&payload.path, None).await.map_err(|e| {
                     error!("Open: wslpath failed: {}", e);
                     StatusCode::INTERNAL_SERVER_ERROR
                 })?;
@@ -1033,7 +1030,7 @@ async fn open_handler(Json(payload): Json<OpenParams>) -> Result<StatusCode, Sta
 
         #[cfg(target_os = "linux")]
         if env::var("WSL_DISTRO_NAME").is_ok() {
-            let win_path = wslpath_to_windows(&payload.path).await.map_err(|e| {
+            let win_path = wslpath_to_windows(&payload.path, None).await.map_err(|e| {
                 error!("Open: wslpath failed: {}", e);
                 StatusCode::INTERNAL_SERVER_ERROR
             })?;
@@ -1060,7 +1057,7 @@ async fn open_handler(Json(payload): Json<OpenParams>) -> Result<StatusCode, Sta
 }
 
 async fn stat_handler(Query(query): Query<StatParams>) -> Result<Json<StatResponse>, StatusCode> {
-    let file_path = match normalize_path(&query.path, query.is_wsl).await {
+    let file_path = match normalize_path(&query.path, query.wsl_distro.as_deref()).await {
         Ok(path) => path,
         Err(error) => {
             return Ok(Json(StatResponse::StatResponseErr {
@@ -1078,8 +1075,8 @@ async fn stat_handler(Query(query): Query<StatParams>) -> Result<Json<StatRespon
 
     match result {
         Ok((mtime, path_type)) => {
-            let windows_path = if query.is_wsl {
-                wslpath_to_windows(&query.path).await.ok()
+            let windows_path = if let Some(distro) = query.wsl_distro.as_deref() {
+                wslpath_to_windows(&query.path, Some(distro)).await.ok()
             } else {
                 None
             };
@@ -1100,7 +1097,7 @@ async fn stat_handler(Query(query): Query<StatParams>) -> Result<Json<StatRespon
 async fn listdir_handler(
     Query(query): Query<ListDirParams>,
 ) -> Result<Json<ListDirResponse>, StatusCode> {
-    let dir_path = match normalize_path(&query.path, query.is_wsl).await {
+    let dir_path = match normalize_path(&query.path, query.wsl_distro.as_deref()).await {
         Ok(path) => path,
         Err(error) => {
             return Ok(Json(ListDirResponse::ListDirResponseErr {
@@ -1131,7 +1128,7 @@ async fn listdir_handler(
 async fn mkdir_handler(
     Json(payload): Json<MkdirParams>,
 ) -> Result<Json<MkdirResponse>, StatusCode> {
-    let dir_path = match normalize_path(&payload.path, payload.is_wsl).await {
+    let dir_path = match normalize_path(&payload.path, payload.wsl_distro.as_deref()).await {
         Ok(path) => path,
         Err(error) => {
             return Ok(Json(MkdirResponse::MkdirResponseErr {
@@ -1224,29 +1221,27 @@ async fn which_handler(Json(params): Json<WhichParams>) -> Result<Json<WhichResp
     #[cfg(target_os = "windows")]
     {
         // Check if we're in WSL context
-        if let Some(env) = &params.env {
-            if env.get("WSL_DISTRO_NAME").is_some() {
-                // Run which command inside WSL
-                let cwd = params.cwd.as_deref().unwrap_or(".");
-                let env_clone = env.clone();
-                let command_str = format!("which {}", params.command);
+        if let Some(distro) = params.wsl_distro.as_deref() {
+            // Run which command inside WSL
+            let cwd = params.cwd.as_deref().unwrap_or(".");
+            let env_clone = params.env.clone().unwrap_or_default();
+            let command_str = format!("which {}", params.command);
 
-                let mut command = create_shell_command(&command_str, env_clone, cwd, params.is_wsl);
-                command.stdout(Stdio::piped()).stderr(Stdio::piped());
+            let mut command = create_shell_command(&command_str, env_clone, cwd, Some(distro));
+            command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-                let output = command
-                    .output()
-                    .await
-                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            let output = command
+                .output()
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-                if output.status.success() {
-                    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                    if !path.is_empty() {
-                        return Ok(Json(WhichResponse { path: Some(path) }));
-                    }
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return Ok(Json(WhichResponse { path: Some(path) }));
                 }
-                return Ok(Json(WhichResponse { path: None }));
             }
+            return Ok(Json(WhichResponse { path: None }));
         }
     }
 
@@ -1295,8 +1290,8 @@ async fn about_handler(
 
     #[cfg(target_os = "windows")]
     {
-        if params.is_wsl {
-            let mut command = create_shell_command("uname -m", HashMap::new(), "~", true);
+        if let Some(distro) = params.wsl_distro.as_deref() {
+            let mut command = create_shell_command("uname -m", HashMap::new(), "~", Some(distro));
             command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
             let output = command

--- a/tidewave-core/src/utils.rs
+++ b/tidewave-core/src/utils.rs
@@ -52,13 +52,19 @@ fn load_tls_config(
 }
 
 /// Converts a WSL path to a Windows path using wslpath.
-pub async fn wslpath_to_windows(wsl_path: &str) -> Result<String, String> {
+pub async fn wslpath_to_windows(
+    wsl_path: &str,
+    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] wsl_distro: Option<&str>,
+) -> Result<String, String> {
     use std::process::Stdio;
     use tokio::process::Command;
 
     #[cfg(target_os = "windows")]
     let mut command = {
         let mut cmd = Command::new("wsl.exe");
+        if let Some(distro) = wsl_distro {
+            cmd.arg("-d").arg(distro);
+        }
         cmd.arg("-e")
             .arg("wslpath")
             .arg("-w")
@@ -103,10 +109,10 @@ pub fn recordings_dir() -> PathBuf {
 
 /// Normalizes a path, converting WSL paths to Windows paths if needed.
 #[allow(unused_variables)]
-pub async fn normalize_path(path: &str, is_wsl: bool) -> Result<String, String> {
+pub async fn normalize_path(path: &str, wsl_distro: Option<&str>) -> Result<String, String> {
     #[cfg(target_os = "windows")]
-    if is_wsl {
-        return wslpath_to_windows(path).await;
+    if let Some(distro) = wsl_distro {
+        return wslpath_to_windows(path, Some(distro)).await;
     }
 
     Ok(path.to_string())

--- a/tidewave-core/src/ws/acp.rs
+++ b/tidewave-core/src/ws/acp.rs
@@ -189,7 +189,7 @@ pub struct TidewaveSpawnOptions {
     pub env: HashMap<String, String>,
     pub cwd: String,
     #[serde(default)]
-    pub is_wsl: bool,
+    pub wsl_distro: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1976,7 +1976,7 @@ pub fn real_process_starter() -> ProcessStarterFn {
                 &spawn_opts.command,
                 spawn_opts.env,
                 &spawn_opts.cwd,
-                spawn_opts.is_wsl,
+                spawn_opts.wsl_distro.as_deref(),
             );
 
             cmd.stdin(Stdio::piped())
@@ -2027,7 +2027,7 @@ mod tests {
             command: "test_cmd".to_string(),
             env: HashMap::new(),
             cwd: ".".to_string(),
-            is_wsl: false,
+            wsl_distro: None,
         }
     }
 

--- a/tidewave-core/src/ws/terminal.rs
+++ b/tidewave-core/src/ws/terminal.rs
@@ -47,7 +47,8 @@ struct JoinPayload {
     env: HashMap<String, String>,
     cwd: String,
     #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
-    is_wsl: bool,
+    #[serde(default)]
+    wsl_distro: Option<String>,
 }
 
 fn default_cols() -> u16 {
@@ -60,12 +61,12 @@ fn default_rows() -> u16 {
 
 /// Build the PTY command based on the join payload.
 ///
-/// On Windows with `is_wsl`, spawns `wsl.exe` with the user's shell (from the
-/// `SHELL` env var, falling back to `sh`). Otherwise uses the default program
-/// (the user's native shell).
+/// On Windows with `wsl_distro` set, spawns `wsl.exe -d <distro>` with the
+/// user's shell (from the `SHELL` env var, falling back to `sh`). Otherwise
+/// uses the default program (the user's native shell).
 fn build_shell_command(payload: &JoinPayload) -> CommandBuilder {
     #[cfg(target_os = "windows")]
-    if payload.is_wsl {
+    if let Some(distro) = payload.wsl_distro.as_deref() {
         let shell = payload.env.get("SHELL").map(|s| s.as_str()).unwrap_or("sh");
 
         // Build env assignments string: VAR1='value1' VAR2='value2' ...
@@ -86,6 +87,8 @@ fn build_shell_command(payload: &JoinPayload) -> CommandBuilder {
         };
 
         let mut cmd = CommandBuilder::new("wsl.exe");
+        cmd.arg("-d");
+        cmd.arg(distro);
         cmd.arg("--cd");
         cmd.arg(&payload.cwd);
         cmd.arg("sh");

--- a/tidewave-core/src/ws/watch.rs
+++ b/tidewave-core/src/ws/watch.rs
@@ -97,7 +97,7 @@ impl WatchFeatureState {
 struct JoinPayload {
     path: String,
     #[serde(default)]
-    is_wsl: bool,
+    wsl_distro: Option<String>,
 }
 
 /// Initialize a `watch:<ref>` channel.
@@ -119,7 +119,7 @@ pub async fn init(
     };
 
     // Normalize path (handles WSL path conversion on Windows)
-    let normalized_path = match normalize_path(&payload.path, payload.is_wsl).await {
+    let normalized_path = match normalize_path(&payload.path, payload.wsl_distro.as_deref()).await {
         Ok(p) => p,
         Err(e) => return InitResult::Error(format!("Failed to normalize path: {}", e)),
     };
@@ -164,7 +164,12 @@ pub async fn init(
         .is_ok();
 
     if should_start_watcher {
-        init_watcher(&state, &active_watch, &canonical_path, payload.is_wsl);
+        init_watcher(
+            &state,
+            &active_watch,
+            &canonical_path,
+            payload.wsl_distro.as_deref(),
+        );
     }
 
     // Send success reply
@@ -210,7 +215,7 @@ fn init_watcher(
     state: &WatchFeatureState,
     active_watch: &Arc<ActiveWatch>,
     canonical_path: &str,
-    is_wsl: bool,
+    wsl_distro: Option<&str>,
 ) {
     let tx = active_watch.tx.clone();
     let canonical_path = canonical_path.to_string();
@@ -219,10 +224,10 @@ fn init_watcher(
     // On Windows with WSL, use poll watcher directly since native watcher
     // doesn't work well with WSL paths
     #[cfg(target_os = "windows")]
-    let use_poll_watcher = is_wsl;
+    let use_poll_watcher = wsl_distro.is_some();
     #[cfg(not(target_os = "windows"))]
     let use_poll_watcher = {
-        let _ = is_wsl;
+        let _ = wsl_distro;
         false
     };
 


### PR DESCRIPTION
The client now also sends `wsl_distro`, so we use that in the place of `is_wsl`. We pass the distro name to the `wsl` command via the `-d` flag, so we don't rely on the distro being the default.